### PR TITLE
Update to CTFd 3.7.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.7.0@sha256:e4e886aa8f1051eeddcabe2115bc9a5f380be2b54034d5a119c44b177d6b8c57
+        image: ctfd/ctfd:3.7.3@sha256:90470e1fe0f93028ce6ac197b8942916ee157d4b5d33c8266c5bec7662e55ac3
         ports:
           - 8000:8000
     steps:

--- a/cmd/ctfd-setup/main.go
+++ b/cmd/ctfd-setup/main.go
@@ -66,6 +66,12 @@ func main() {
 				EnvVars:  []string{"APPEARANCE_DESCRIPTION", "PLUGIN_APPEARANCE_DESCRIPTION"},
 				Category: configuration,
 			},
+			&cli.StringFlag{
+				Name:     "appearance.default_locale",
+				Usage:    "The default language for the users.",
+				EnvVars:  []string{"APPEARANCE_DEFAULT_LOCALE", "PLUGIN_APPEARANCE_DEFAULT_LOCALE"},
+				Category: configuration,
+			},
 			// => Theme
 			&cli.StringFlag{
 				Name:     "theme.logo",
@@ -477,8 +483,9 @@ func run(ctx *cli.Context) error {
 	}
 	conf := &ctfdsetup.Config{
 		Appearance: ctfdsetup.Appearance{
-			Name:        ctx.String("appearance.name"),
-			Description: ctx.String("appearance.description"),
+			Name:          ctx.String("appearance.name"),
+			Description:   ctx.String("appearance.description"),
+			DefaultLocale: stringPtr(ctx, "appearance.default_locale"),
 		},
 		Theme: ctfdsetup.Theme{
 			Logo:      logo,

--- a/config.go
+++ b/config.go
@@ -27,8 +27,9 @@ type (
 	}
 
 	Appearance struct {
-		Name        string `yaml:"name"`        // required
-		Description string `yaml:"description"` // required
+		Name          string  `yaml:"name"`        // required
+		Description   string  `yaml:"description"` // required
+		DefaultLocale *string `yaml:"default_locale"`
 	}
 
 	Theme struct {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ctfer-io/ctfd-setup
 go 1.22.2
 
 require (
-	github.com/ctfer-io/go-ctfd v0.8.1
+	github.com/ctfer-io/go-ctfd v0.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.27.2
 	go.uber.org/multierr v1.11.0
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/gorilla/schema v1.3.0 // indirect
+	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/ctfer-io/go-ctfd v0.8.1 h1:/cXBR6rJ6S4Q2w7HS5otQvyQ4GK9pzDTsrqCxOl69oc=
-github.com/ctfer-io/go-ctfd v0.8.1/go.mod h1:zOOgs1LmKEVW3rilcog0jT921vjShmR3avJbSMtvNyM=
+github.com/ctfer-io/go-ctfd v0.9.0 h1:udhuLkUgQ0hWBbE8Qzo4hZWVdUtEocp1t7xRIwDFqs4=
+github.com/ctfer-io/go-ctfd v0.9.0/go.mod h1:jNeeXui6iW1jsAfa4D5v6MaK0UF26CtjTRtCqS/PWH4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/schema v1.3.0 h1:rbciOzXAx3IB8stEFnfTwO3sYa6EWlQk79XdyustPDA=
-github.com/gorilla/schema v1.3.0/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
+github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
+github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/setup.go
+++ b/setup.go
@@ -117,6 +117,7 @@ func updateSetup(ctx context.Context, client *api.Client, conf *Config) error {
 	params := &api.PatchConfigsParams{
 		CTFDescription:                     &conf.Appearance.Description,
 		CTFName:                            &conf.Appearance.Name,
+		DefaultLocale:                      conf.Appearance.DefaultLocale,
 		CTFTheme:                           &conf.Theme.Name,
 		ThemeFooter:                        ptr(string(conf.Theme.Footer.Content)),
 		ThemeHeader:                        ptr(string(conf.Theme.Header.Content)),


### PR DESCRIPTION
This PR comes with the updates of CTFd 3.7.3 (see [changelog here](https://github.com/CTFd/CTFd/releases/tag/3.7.3)).

Once merged, will require a minor tag.