### PR TITLE
fix: default CTFd theme is now core-beta as of ctfd/ctfd#2629

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
     description: 'The frontend small icon. Provide a path to a locally-accessible file.'
   theme_name:
     description: 'The frontend theme name.'
-    default: 'core'
+    default: 'core-beta'
   theme_color:
     description: 'The frontend theme color.'
   theme_header:

--- a/cmd/ctfd-setup/main.go
+++ b/cmd/ctfd-setup/main.go
@@ -88,7 +88,7 @@ func main() {
 			&cli.StringFlag{
 				Name:     "theme.name",
 				Usage:    "The frontend theme name.",
-				Value:    "core",
+				Value:    "core-beta",
 				EnvVars:  []string{"THEME_NAME", "PLUGIN_THEME_NAME"},
 				Category: configuration,
 			},


### PR DESCRIPTION
This PR sets the new default theme to `core-beta` as it was discussed in ctfd/ctfd#2629.

Once accepted, a tag will be created.