### PR TITLE
Docker images publishing: SLSA 3 and SBOMs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,59 @@
+name: Build Docker images
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        id: build
+        with:
+          push: true
+          sbom: true # may not produce SBOM in manifest if the image has no filesystem (e.g. "FROM scratch")
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # This step calls the container workflow to generate provenance and push it to
+  # the container registry.
+  provenance:
+    needs: [docker]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ github.repository }}
+      digest: ${{ needs.docker.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,12 +29,6 @@ jobs:
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@1ca97d9028b51809cf6d3c934c3e160716e1b605 # v0.17.5
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,16 +16,6 @@ builds:
       - amd64
     binary: "{{ .ProjectName }}"
 
-dockers:
-  - image_templates:
-      - "ctferio/{{ .ProjectName }}:latest"
-      - "ctferio/{{ .ProjectName }}:{{ .Tag }}"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+FROM golang:1.23.2@sha256:ad5c126b5cf501a8caef751a243bb717ec204ab1aa56dc41dc11be089fafcb4f AS builder
+
+WORKDIR /go/src
+COPY go.mod go.sum .
+RUN go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN go build -cover -o /go/bin/ctfd-setup cmd/ctfd-setup/main.go
+
+
+
 FROM scratch
-COPY ctfd-setup /
+COPY --from=builder /go/bin/ctfd-setup /ctfd-setup
 ENTRYPOINT [ "/ctfd-setup" ]

--- a/README.md
+++ b/README.md
@@ -88,3 +88,40 @@ steps:
         from_secret: ADMIN_PASSWORD
       # ... and so on (non-mandatory attributes)
 ```
+
+## Security
+
+### Signature and Attestations
+
+For deployment purposes (and especially in the deployment case of Kubernetes), you may want to ensure the integrity of what you run.
+
+The release assets are SLSA 3 and can be verified using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) using the following.
+
+```bash
+slsa-verifier verify-artifact "<path/to/release_artifact>"  \
+  --provenance-path "<path/to/release_intoto_attestation>"  \
+  --source-uri "github.com/ctfer-io/ctfd-setup" \
+  --source-tag "<tag>"
+```
+
+The Docker image is SLSA 3 and can be verified using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) using the following.
+
+```bash
+slsa-verifier slsa-verifier verify-image "ctferio/ctfd-setup:<tag>@sha256:<digest>" \
+    --source-uri "github.com/ctfer-io/ctfd-setup" \
+    --source-tag "<tag>"
+```
+
+Alternatives exist, like [Kyverno](https://kyverno.io/) for a Kubernetes-based deployment.
+
+### SBOMs
+
+A SBOM for the whole repository is generated on each release and can be found in the assets of it.
+They are signed as SLSA 3 assets. Refer to [Signature and Attestations](#signature-and-attestations) to verify their integrity.
+
+A SBOM is generated for the Docker image in its manifest, and can be inspected using the following.
+
+```bash
+docker buildx imagetools inspect "ctferio/ctfd-setup:<tag>" \
+    --format "{{ json .SBOM.SPDX }}"
+```


### PR DESCRIPTION
In this PR I propose to remove the role of building and publishing Docker images from goreleaser. The reasoning is that we need to propagate metadata manually, and whatever we do, we cannot easily produce SBOMs and sign the images.

Due to this limitation, and the necessity to achieve SLSA 3 on a Kubernetes cluster through Kyverno for CTFer.io clusters, we need this PR.
On everyday's life of the asset, those security features won't be used but it does not interfere with the functionalities.
