### PR TITLE
Update CTFd to 3.7.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctfd/ctfd:3.7.3@sha256:90470e1fe0f93028ce6ac197b8942916ee157d4b5d33c8266c5bec7662e55ac3
+        image: ctfd/ctfd:3.7.5@sha256:7f456b23727286c9df2b58e0b7398cc0196e2b74e4c1c5b3cda7a5b71034637d
         ports:
           - 8000:8000
     steps:


### PR DESCRIPTION
This PR upates CTFd to v3.7.5. Was tested locally with the NoBrackets 2024 example and it worked fine. This was to except as the changelog does not state any change in the setup process :smile: