### PR TITLE
Pilot the context directory to use when parsing files

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,8 @@ branding:
 inputs:
   file:
     description: 'Configuration file to use for setting up CTFd. If let empty, will default the values and look for secrets in expected environment variables. For more info, refers to the documentation.'
+  dir:
+    description: 'The directory to parse from.'
   url:
     description: 'URL to reach the CTFd instance.'
     required: true

--- a/cmd/ctfd-setup/main.go
+++ b/cmd/ctfd-setup/main.go
@@ -40,6 +40,13 @@ func main() {
 				Category: management,
 			},
 			&cli.StringFlag{
+				Name:        "dir",
+				Usage:       "The directory to parse from.",
+				EnvVars:     []string{"DIRECTORY"},
+				Category:    management,
+				Destination: &ctfdsetup.Directory,
+			},
+			&cli.StringFlag{
 				Name:     "url",
 				Usage:    "URL to reach the CTFd instance.",
 				EnvVars:  []string{"URL", "PLUGIN_URL"},

--- a/file.go
+++ b/file.go
@@ -2,9 +2,14 @@ package ctfdsetup
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/invopop/jsonschema"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	Directory string
 )
 
 type File struct {
@@ -31,7 +36,7 @@ func (file *File) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 	}
 
-	fc, err := os.ReadFile(*lfiv.FromFile)
+	fc, err := os.ReadFile(filepath.Join(Directory, *lfiv.FromFile))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context

When using the action or `ctfd-setup` in CLI, you use it within your filesystem target.
Nevertheless, this is not always the case : you may use a monorepo or use the exposed API to sets up CTFd.

## This PR

In this PR, I simply add the capability to set the `directory` to use when opening files.
