### PR TITLE
fix!: typo in attribute name

### DIFF
--- a/config.go
+++ b/config.go
@@ -96,7 +96,7 @@ type (
 		TeamDisbanding *string `yaml:"team_disbanding,omitempty" json:"team_disbanding,omitempty"`
 
 		// Maximum number of invalid submissions per minute (per user/team). We suggest you use it as part of an anti-brute-force strategy (rate limiting).
-		IncorrectSubmissionsPerMinute *int `yaml:"incorrect_submissions_per_minutes,omitempty" json:"incorrect_submissions_per_minutes,omitempty"`
+		IncorrectSubmissionsPerMinute *int `yaml:"incorrect_submissions_per_minute,omitempty" json:"incorrect_submissions_per_minute,omitempty"`
 
 		// Whether a user can change its name or not.
 		NameChanges *bool `yaml:"name_changes,omitempty" json:"name_changes,omitempty"`


### PR DESCRIPTION
This PR fixes a typo in the accounts structure name of `incorrect_submissions_per_minute`. It was properly mapped in the tool, but not with the CLI.

It does not impact the CLI nor the action API, but is :rotating_light: **breaking** :rotating_light: [dependents Go modules](https://github.com/ctfer-io/ctfd-setup/network/dependents?package_id=UGFja2FnZS00NzIzMDg3NTEz) i.e. none at the time of writing.