### PR TITLE
fix: nil pointer dereference after `NewConfig` is called

### DIFF
--- a/config.go
+++ b/config.go
@@ -335,7 +335,9 @@ func NewConfig() *Config {
 		Security: &Security{},
 		Email:    &Email{},
 		Time:     &Time{},
-		Social:   &Social{},
+		Social: &Social{
+			Template: &File{},
+		},
 		Legal: &Legal{
 			TOS: ExternalReference{
 				Content: &File{},


### PR DESCRIPTION
This PR fixes the `NewConfig` returned value. If used programatically, `ctfd-setup` dereference a nil pointer thus panics.
Using the CLI or action it does not panics as it binds not using this default config.