### PR TITLE
fix: action latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Setup CTFd'
-        uses: 'ctfer-io/ctfd-setup@v1.6.0'
+        uses: 'ctfer-io/ctfd-setup@v1.7.2'
         with:
           url: ${{ secrets.CTFD_URL }}
           file: '.ctfd.yaml'
@@ -115,7 +115,7 @@ steps:
   # ...
 
   - name: 'Setup CTFd'
-    image: 'ctferio/ctfd-setup@v1.6.0'
+    image: 'ctferio/ctfd-setup@v1.7.2'
     settings:
       url:
         from_secret: CTFD_URL

--- a/action.yaml
+++ b/action.yaml
@@ -171,7 +171,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ctferio/ctfd-setup:v1.6.0'
+  image: 'docker://ctferio/ctfd-setup:v1.7.2'
   env:
     FILE: ${{ inputs.file }}
     URL: ${{ inputs.url }}


### PR DESCRIPTION
Resolves #192

It targets a future tag (one that will be created after this PR), and is necessary. Else actions won't be able to pull latest tag + be coherent with their respective schema.