### PR TITLE
fix(ci): bump Node to 22 (latest LTS)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: './schemastore/package-lock.json'
 


### PR DESCRIPTION
This PR fixes the two-weeks-old CI issue (does not run anymore).

The patch is simple: run on the latest Node version :wink: